### PR TITLE
fix: Correctly parse indented code blocks

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -32,6 +32,8 @@ export interface Action {
     actionLineNum: number;
     filename: string;
     lines?: string[];
+    /** Number of spaces of the indent */
+    indent: number;
 }
 
 export type ActionComplete = WithRequiredT<Action, "lines">;
@@ -40,6 +42,8 @@ export type NonActionType = "codetag" | "text";
 
 export interface NonAction {
     type: NonActionType;
+    /** Number of spaces of the indent */
+    indent: number;
 }
 
 export type LineType = Action | NonAction;

--- a/test/actions/exec.spec.ts
+++ b/test/actions/exec.spec.ts
@@ -41,6 +41,7 @@ describe("exec action", () => {
         const action: Action = {
             type: "exec",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, cmd: "echo 'Output line'; exit 5" },
         };
@@ -58,6 +59,7 @@ Output line
         const action: Action = {
             type: "exec",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, cmd: ["echo", "Some output"] },
         };
@@ -70,6 +72,7 @@ Output line
         const action: Action = {
             type: "exec",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, cmd: ["FOO"] },
         };
@@ -85,6 +88,7 @@ spawn FOO ENOENT`);
         const action: Action = {
             type: "exec",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, cmd: ["ls", "BADFILE"] },
         };

--- a/test/actions/output.spec.ts
+++ b/test/actions/output.spec.ts
@@ -13,6 +13,7 @@ describe("output action", () => {
         const action: Action = {
             type: "output",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, matchRegex: "test" },
         };
@@ -25,6 +26,7 @@ describe("output action", () => {
         const action: Action = {
             type: "output",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, matchRegex: "(foo" },
         };
@@ -37,6 +39,7 @@ describe("output action", () => {
         const action: Action = {
             type: "output",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, matchRegex: "foo", regexFlags: "Q" },
         };
@@ -49,6 +52,7 @@ describe("output action", () => {
         const action: Action = {
             type: "output",
             filename,
+            indent: 0,
             actionLineNum,
             params: { step: false, matchRegex: "foo" },
         };

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -20,10 +20,37 @@ describe("parseFile", () => {
                 type: "command",
                 filename: "<string>",
                 actionLineNum: 2,
+                indent: 0,
                 params: {},
                 lines: [
                     "command one",
                     "another command",
+                ]
+            }
+        ]);
+    });
+
+    it("should parse indented command code block", async () => {
+        const md = [
+            "1. A list",
+            "",
+            "<!-- doctest command -->",
+            "    ```",
+            "     command one",
+            "      another command",
+            "    ```",
+        ].join("\n");
+        const actions = await readString(dt, md);
+        should(actions).eql([
+            {
+                type: "command",
+                actionLineNum: 3,
+                indent: 4,
+                filename: "<string>",
+                params: {},
+                lines: [
+                    " command one",
+                    "  another command",
                 ]
             }
         ]);


### PR DESCRIPTION
Code blocks within lists, etc. were not getting parsed correctly, resulting in warnings and the commands not being run.
